### PR TITLE
Resolved import error for ExceptionNotFound

### DIFF
--- a/naiveBayesClassifier/classifier.py
+++ b/naiveBayesClassifier/classifier.py
@@ -2,7 +2,8 @@ from __future__ import division
 import operator
 from functools import reduce
 
-from ExceptionNotSeen import NotSeen
+from naiveBayesClassifier.ExceptionNotSeen import NotSeen
+
 
 class Classifier(object):
     """docstring for Classifier"""

--- a/naiveBayesClassifier/trainedData.py
+++ b/naiveBayesClassifier/trainedData.py
@@ -1,4 +1,5 @@
-from ExceptionNotSeen import NotSeen
+from naiveBayesClassifier.ExceptionNotSeen import NotSeen
+
 
 class TrainedData(object):
     def __init__(self):


### PR DESCRIPTION
Currently, the module will not function as the example shows because the following Error is raised:

`ImportError: No module named 'ExceptionNotSeen'`

To avoid this error we would need to import everything as a wild card with the following:

`from naiveBayesClassifier import *`

Or we can namespace the ExceptionNotSeen module as shown in the commit.

I followed a similar structure to how the trainer imports TrainedData

`from naiveBayesClassifier.trainedData import TrainedData`.